### PR TITLE
Corrige le bouton "Créer un compte" sur accueil

### DIFF
--- a/assets/styles/components/home.css
+++ b/assets/styles/components/home.css
@@ -1,7 +1,6 @@
 .home-jumbotron {
   position: relative;
   overflow: hidden;
-  z-index: -2;
 }
 
 .home-jumbotron::before {
@@ -11,6 +10,7 @@
   top: 0;
   width: 100%;
   height: 100%;
+  background-color: var(--background-flat-yellow);
   background-image: url("/public/images/home/jumbotron-mobile.svg");
   background-repeat: no-repeat;
   background-size: 500px auto;

--- a/templates/index.html.twig
+++ b/templates/index.html.twig
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block main %}
-    <div class="home-jumbotron j-box j-background-flat-yellow">
+    <div class="home-jumbotron j-box">
         <div class="j-container">
             <div class="j-stack" style="--stack-gap: calc(3 * var(--w))">
                 <img src="{{ asset('images/logo-orange.svg') }}" width="150px" height="auto" alt="">


### PR DESCRIPTION
Closes #81 

Le jumbotron était en z-index: -2 pour que le ::before avec les images en z-index: -1 s'affiche par-dessus

Ce qu'il fallait faire c'est laisser le jumbotron sans z-index, et mettre la background-color dans le ::before contenant l'image