### PR TITLE
Refactor : ne pas utiliser is="..."

### DIFF
--- a/assets/customElements/index.js
+++ b/assets/customElements/index.js
@@ -3,5 +3,5 @@ import navButton from "./navButton";
 import passwordInput from "./passwordInput";
 
 customElements.define("j-clickable-card", clickableCard);
-customElements.define("j-nav-button", navButton, { extends: "button" });
+customElements.define("j-nav-button", navButton);
 customElements.define("j-password-input", passwordInput);

--- a/assets/customElements/navButton.js
+++ b/assets/customElements/navButton.js
@@ -1,20 +1,22 @@
-export default class extends HTMLButtonElement {
+export default class extends HTMLElement {
   connectedCallback() {
     const closeBtn = document.querySelector(
       "[data-nav-button-target=closeBtn]",
     );
     const modal = document.querySelector("[data-nav-button-target=modal]");
 
-    this.addEventListener("click", () => {
-      this.setAttribute("aria-expanded", true);
+    const triggerBtn = this.querySelector("button");
+
+    triggerBtn.addEventListener("click", () => {
+      triggerBtn.setAttribute("aria-expanded", true);
       modal.hidden = false;
       closeBtn.focus();
     });
 
     closeBtn.addEventListener("click", () => {
-      this.setAttribute("aria-expanded", false);
+      triggerBtn.setAttribute("aria-expanded", false);
       modal.hidden = true;
-      this.focus();
+      triggerBtn.focus();
     });
   }
 }

--- a/templates/common/_header.html.twig
+++ b/templates/common/_header.html.twig
@@ -1,15 +1,16 @@
 <header class="j-header">
     <div class="j-header-brand-container">
-        <button
-            is="j-nav-button"
-            class="j-btn j-btn--icon j-header-brand-menu-btn j-header-brand-left"
-            aria-haspopup="true"
-            aria-expanded="false"
-            aria-controls="j-mobile-menu"
-            aria-label="{{ 'nav.mobile.open'|trans }}"
-        >
-            {% include 'common/icons/menu.svg.twig' %}
-        </button>
+        <j-nav-button class="j-header-brand-menu-btn j-header-brand-left">
+            <button
+                class="j-btn j-btn--icon"
+                aria-haspopup="true"
+                aria-expanded="false"
+                aria-controls="j-mobile-menu"
+                aria-label="{{ 'nav.mobile.open'|trans }}"
+            >
+                {% include 'common/icons/menu.svg.twig' %}
+            </button>
+        </j-nav-button>
 
         {% block brand %}
             <a class="j-header-brand" href="{{ brand_url }}">


### PR DESCRIPTION
Malheureusement [is="..." (aka "custom built-in elements") ne fonctionne pas sous Safari](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/is#browser_compatibility)

Donc cette PR retire la dernière occurrence de ça dans le code

Les tests E2E sur la navigation passent